### PR TITLE
Retrieve images when they're remote

### DIFF
--- a/Auk/Auk.swift
+++ b/Auk/Auk.swift
@@ -193,6 +193,8 @@ public class Auk {
     for page in AukScrollViewContent.aukPages(scrollView) {
       if let image = page.imageView?.image {
         images.append(image)
+      } else if let image = page.remoteImageView?.image {
+        images.append(image)
       }
     }
     


### PR DESCRIPTION
When using the images method to retrieve the images in the slideshow, it only returns the local ones, but not the remote ones. This commit makes it return the images that have already been loaded in the slideshow.