### PR TITLE
Horizontal margin between pages

### DIFF
--- a/Auk/AukScrollViewContent.swift
+++ b/Auk/AukScrollViewContent.swift
@@ -45,7 +45,7 @@ struct AukScrollViewContent {
       page.translatesAutoresizingMaskIntoConstraints = false
       
       // Make page size equal to the scroll view size
-      scrollView.addConstraint(NSLayoutConstraint(item: page, attribute: .Width, relatedBy: .Equal, toItem: scrollView, attribute: .Width, multiplier: 1, constant: -settings.horizontalPageMargin * 2))
+      scrollView.addConstraint(NSLayoutConstraint(item: page, attribute: .width, relatedBy: .equal, toItem: scrollView, attribute: .width, multiplier: 1, constant: -settings.horizontalPageMargin * 2))
       iiAutolayoutConstraints.equalHeight(page, viewTwo: scrollView, constraintContainer: scrollView)
       // Stretch the page vertically to fill the height of the scroll view
       iiAutolayoutConstraints.fillParent(page, parentView: scrollView, margin: 0, vertically: true)

--- a/Auk/AukScrollViewContent.swift
+++ b/Auk/AukScrollViewContent.swift
@@ -35,7 +35,7 @@ struct AukScrollViewContent {
   */
   static func layout(_ scrollView: UIScrollView) {
     let pages = aukPages(scrollView)
-
+    let settings = scrollView.auk.settings
     for (index, page) in pages.enumerated() {
       
       // Delete current constraints by removing the view and adding it back to its superview
@@ -45,27 +45,27 @@ struct AukScrollViewContent {
       page.translatesAutoresizingMaskIntoConstraints = false
       
       // Make page size equal to the scroll view size
-      iiAutolayoutConstraints.equalSize(page, viewTwo: scrollView, constraintContainer: scrollView)
-      
+      scrollView.addConstraint(NSLayoutConstraint(item: page, attribute: .Width, relatedBy: .Equal, toItem: scrollView, attribute: .Width, multiplier: 1, constant: -settings.horizontalPageMargin * 2))
+      iiAutolayoutConstraints.equalHeight(page, viewTwo: scrollView, constraintContainer: scrollView)
       // Stretch the page vertically to fill the height of the scroll view
       iiAutolayoutConstraints.fillParent(page, parentView: scrollView, margin: 0, vertically: true)
       
       if index == 0 {
         // Align the leading edge of the first page to the leading edge of the scroll view.
         iiAutolayoutConstraints.alignSameAttributes(page, toItem: scrollView,
-          constraintContainer: scrollView, attribute: NSLayoutAttribute.leading, margin: 0)
+          constraintContainer: scrollView, attribute: NSLayoutAttribute.leading, margin: settings.horizontalPageMargin)
       }
       
       if index == pages.count - 1 {
         // Align the trailing edge of the last page to the trailing edge of the scroll view.
         iiAutolayoutConstraints.alignSameAttributes(page, toItem: scrollView,
-          constraintContainer: scrollView, attribute: NSLayoutAttribute.trailing, margin: 0)
+          constraintContainer: scrollView, attribute: NSLayoutAttribute.trailing, margin: settings.horizontalPageMargin)
       }
     }
     
     // Align page next to each other
     iiAutolayoutConstraints.viewsNextToEachOther(pages, constraintContainer: scrollView,
-      margin: 0, vertically: false)
+      margin: settings.horizontalPageMargin * 2, vertically: false)
     
     scrollView.layoutIfNeeded()
   }

--- a/Auk/AukSettings.swift
+++ b/Auk/AukSettings.swift
@@ -34,6 +34,9 @@ public struct AukSettings {
   
   /// Show horizontal scroll indicator.
   public var showsHorizontalScrollIndicator = false
+  
+  /// Horizontal margin on left and right of each page.
+  public var horizontalPageMargin : CGFloat = 0
 }
 
 /**

--- a/Auk/Utils/iiAutolayoutConstraints.swift
+++ b/Auk/Utils/iiAutolayoutConstraints.swift
@@ -49,7 +49,7 @@ class iiAutolayoutConstraints {
   }
   
   // MARK: - Equal height and width
-  
+  @discardableResult
   class func equalHeight(_ viewOne: UIView, viewTwo: UIView, constraintContainer: UIView) -> [NSLayoutConstraint] {
     
     return equalWidthOrHeight(viewOne, viewTwo: viewTwo, constraintContainer: constraintContainer, isHeight: true)

--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -62,8 +62,8 @@
                                     <action selector="onShowLeftButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Bnx-Yi-260"/>
                                 </connections>
                             </button>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SrW-bD-PlC">
-                                <rect key="frame" x="0.0" y="64" width="600" height="265"/>
+                            <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SrW-bD-PlC">
+                                <rect key="frame" x="60" y="64" width="480" height="265"/>
                                 <gestureRecognizers/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="265" id="Or5-06-LRV"/>
@@ -80,8 +80,9 @@
                             <constraint firstItem="Ak0-JX-tQy" firstAttribute="leading" secondItem="6Cz-ix-YLV" secondAttribute="trailing" constant="35" placeholder="YES" id="IOV-qw-YrA"/>
                             <constraint firstItem="Ak0-JX-tQy" firstAttribute="centerY" secondItem="6Cz-ix-YLV" secondAttribute="centerY" priority="750" id="P6h-3q-fej"/>
                             <constraint firstItem="aWz-f3-FnP" firstAttribute="top" secondItem="6Cz-ix-YLV" secondAttribute="bottom" constant="5" id="Tk8-GY-sRq"/>
-                            <constraint firstItem="SrW-bD-PlC" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="V4N-me-dMl"/>
-                            <constraint firstAttribute="trailing" secondItem="SrW-bD-PlC" secondAttribute="trailing" id="YR5-0D-hJw"/>
+                            <constraint firstItem="SrW-bD-PlC" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="60" id="V4N-me-dMl"/>
+                            <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="XGm-Hv-R70" secondAttribute="trailing" constant="15" id="VCQ-qw-aUb"/>
+                            <constraint firstAttribute="trailing" secondItem="SrW-bD-PlC" secondAttribute="trailing" constant="60" id="YR5-0D-hJw"/>
                             <constraint firstItem="xkS-kK-gCM" firstAttribute="centerY" secondItem="6Cz-ix-YLV" secondAttribute="centerY" priority="750" id="cKN-xL-KH9"/>
                             <constraint firstItem="SrW-bD-PlC" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="cee-jg-d7S"/>
                             <constraint firstAttribute="trailingMargin" secondItem="aWz-f3-FnP" secondAttribute="trailing" id="nWl-7l-d1r"/>

--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="dym-9D-I5G">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11129.15" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" generatesPrototypingConstraints="YES" useTraitCollections="YES" colorMatched="NO" initialViewController="dym-9D-I5G">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <development version="7000" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11103.10"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -15,55 +16,55 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ak0-JX-tQy">
-                                <rect key="frame" x="355" y="339" width="40" height="60"/>
+                                <rect key="frame" x="242" y="339" width="40" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="40" id="6Zr-hM-UvK"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="40"/>
                                 <state key="normal" title="⏩">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="onShowRightButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="85a-Zu-PFa"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Cz-ix-YLV">
-                                <rect key="frame" x="280" y="339" width="40" height="60"/>
+                                <rect key="frame" x="167" y="339" width="40" height="60"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="40"/>
                                 <state key="normal" title="🔁">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="onAutoscrollTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="l6A-hy-GLM"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Image description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aWz-f3-FnP">
-                                <rect key="frame" x="20" y="404" width="560" height="19"/>
+                                <rect key="frame" x="16" y="404" width="343" height="19"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="textColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                                 <color key="shadowColor" red="0.46947995580808077" green="0.46947995580808077" blue="0.46947995580808077" alpha="1" colorSpace="calibratedRGB"/>
                                 <size key="shadowOffset" width="1" height="1"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xkS-kK-gCM">
-                                <rect key="frame" x="205" y="339" width="40" height="60"/>
+                                <rect key="frame" x="92" y="339" width="40" height="60"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="40"/>
                                 <state key="normal" title="⏪">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="onShowLeftButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Bnx-Yi-260"/>
                                 </connections>
                             </button>
                             <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SrW-bD-PlC">
-                                <rect key="frame" x="60" y="64" width="480" height="265"/>
+                                <rect key="frame" x="60" y="64" width="255" height="265"/>
                                 <gestureRecognizers/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="265" id="Or5-06-LRV"/>
@@ -73,7 +74,7 @@
                                 </connections>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" red="0.16862745100000001" green="0.76078431369999999" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.15976734459400177" green="0.7139209508895874" blue="0.80127716064453125" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="6Cz-ix-YLV" firstAttribute="leading" secondItem="xkS-kK-gCM" secondAttribute="trailing" constant="35" placeholder="YES" id="BsQ-1Y-Af1"/>
                             <constraint firstItem="aWz-f3-FnP" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="Cny-sB-dCz"/>
@@ -81,7 +82,6 @@
                             <constraint firstItem="Ak0-JX-tQy" firstAttribute="centerY" secondItem="6Cz-ix-YLV" secondAttribute="centerY" priority="750" id="P6h-3q-fej"/>
                             <constraint firstItem="aWz-f3-FnP" firstAttribute="top" secondItem="6Cz-ix-YLV" secondAttribute="bottom" constant="5" id="Tk8-GY-sRq"/>
                             <constraint firstItem="SrW-bD-PlC" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="60" id="V4N-me-dMl"/>
-                            <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="XGm-Hv-R70" secondAttribute="trailing" constant="15" id="VCQ-qw-aUb"/>
                             <constraint firstAttribute="trailing" secondItem="SrW-bD-PlC" secondAttribute="trailing" constant="60" id="YR5-0D-hJw"/>
                             <constraint firstItem="xkS-kK-gCM" firstAttribute="centerY" secondItem="6Cz-ix-YLV" secondAttribute="centerY" priority="750" id="cKN-xL-KH9"/>
                             <constraint firstItem="SrW-bD-PlC" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="cee-jg-d7S"/>
@@ -98,11 +98,11 @@
                             </connections>
                         </barButtonItem>
                         <button key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="vWm-G7-wjO">
-                            <rect key="frame" x="180" y="2.5" width="240" height="39"/>
+                            <rect key="frame" x="105" y="2.5" width="147" height="39"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <state key="normal" title="Clear">
-                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="calibratedRGB"/>
                             </state>
                             <connections>
                                 <action selector="onDeleteButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="coe-9e-at0"/>

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController, UIScrollViewDelegate {
     
     // When you want to display all pages side by side with an horizontal margin,
     // you need the scrollView width to be smaller than it's superview width and to disable clipsToBounds on the scrollView
-    scrollView.clipsToBounds = true // required when using horizontalPageMargin
+    scrollView.clipsToBounds = false // required when using horizontalPageMargin
     scrollView.auk.settings.horizontalPageMargin = 10
     
     showInitialImage()

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -21,6 +21,11 @@ class ViewController: UIViewController, UIScrollViewDelegate {
     scrollView.auk.settings.placeholderImage = UIImage(named: "great_auk_placeholder.png")
     scrollView.auk.settings.errorImage = UIImage(named: "error_image.png")
     
+    // When you want to display all pages side by side with an horizontal margin,
+    // you need the scrollView width to be smaller than it's superview width and to disable clipsToBounds on the scrollView
+    scrollView.clipsToBounds = true // required when using horizontalPageMargin
+    scrollView.auk.settings.horizontalPageMargin = 10
+    
     showInitialImage()
     showCurrentImageDescription()
   }

--- a/Distrib/AukDistrib.swift
+++ b/Distrib/AukDistrib.swift
@@ -1049,7 +1049,7 @@ struct AukScrollViewContent {
       page.translatesAutoresizingMaskIntoConstraints = false
       
       // Make page size equal to the scroll view size
-      scrollView.addConstraint(NSLayoutConstraint(item: page, attribute: .Width, relatedBy: .Equal, toItem: scrollView, attribute: .Width, multiplier: 1, constant: -settings.horizontalPageMargin * 2))
+      scrollView.addConstraint(NSLayoutConstraint(item: page, attribute: .width, relatedBy: .equal, toItem: scrollView, attribute: .width, multiplier: 1, constant: -settings.horizontalPageMargin * 2))
       iiAutolayoutConstraints.equalHeight(page, viewTwo: scrollView, constraintContainer: scrollView)
       // Stretch the page vertically to fill the height of the scroll view
       iiAutolayoutConstraints.fillParent(page, parentView: scrollView, margin: 0, vertically: true)
@@ -1432,7 +1432,7 @@ class iiAutolayoutConstraints {
   }
   
   // MARK: - Equal height and width
-  
+  @discardableResult
   class func equalHeight(_ viewOne: UIView, viewTwo: UIView, constraintContainer: UIView) -> [NSLayoutConstraint] {
     
     return equalWidthOrHeight(viewOne, viewTwo: viewTwo, constraintContainer: constraintContainer, isHeight: true)

--- a/Distrib/AukDistrib.swift
+++ b/Distrib/AukDistrib.swift
@@ -1039,7 +1039,7 @@ struct AukScrollViewContent {
   */
   static func layout(_ scrollView: UIScrollView) {
     let pages = aukPages(scrollView)
-
+    let settings = scrollView.auk.settings
     for (index, page) in pages.enumerated() {
       
       // Delete current constraints by removing the view and adding it back to its superview
@@ -1049,27 +1049,27 @@ struct AukScrollViewContent {
       page.translatesAutoresizingMaskIntoConstraints = false
       
       // Make page size equal to the scroll view size
-      iiAutolayoutConstraints.equalSize(page, viewTwo: scrollView, constraintContainer: scrollView)
-      
+      scrollView.addConstraint(NSLayoutConstraint(item: page, attribute: .Width, relatedBy: .Equal, toItem: scrollView, attribute: .Width, multiplier: 1, constant: -settings.horizontalPageMargin * 2))
+      iiAutolayoutConstraints.equalHeight(page, viewTwo: scrollView, constraintContainer: scrollView)
       // Stretch the page vertically to fill the height of the scroll view
       iiAutolayoutConstraints.fillParent(page, parentView: scrollView, margin: 0, vertically: true)
       
       if index == 0 {
         // Align the leading edge of the first page to the leading edge of the scroll view.
         iiAutolayoutConstraints.alignSameAttributes(page, toItem: scrollView,
-          constraintContainer: scrollView, attribute: NSLayoutAttribute.leading, margin: 0)
+          constraintContainer: scrollView, attribute: NSLayoutAttribute.leading, margin: settings.horizontalPageMargin)
       }
       
       if index == pages.count - 1 {
         // Align the trailing edge of the last page to the trailing edge of the scroll view.
         iiAutolayoutConstraints.alignSameAttributes(page, toItem: scrollView,
-          constraintContainer: scrollView, attribute: NSLayoutAttribute.trailing, margin: 0)
+          constraintContainer: scrollView, attribute: NSLayoutAttribute.trailing, margin: settings.horizontalPageMargin)
       }
     }
     
     // Align page next to each other
     iiAutolayoutConstraints.viewsNextToEachOther(pages, constraintContainer: scrollView,
-      margin: 0, vertically: false)
+      margin: settings.horizontalPageMargin * 2, vertically: false)
     
     scrollView.layoutIfNeeded()
   }
@@ -1199,6 +1199,9 @@ public struct AukSettings {
   
   /// Show horizontal scroll indicator.
   public var showsHorizontalScrollIndicator = false
+  
+  /// Horizontal margin on left and right of each page.
+  public var horizontalPageMargin : CGFloat = 0
 }
 
 /**


### PR DESCRIPTION
Hello,

PR additions :

* Add of `horizontalPageMargin` setting, it defines how much space there is on each side of a page. ie 10 means for each page there is a 10pt margin on the right and left of each page, which means 20 pt between each pages. I'm not sure this name is the best one to describe this property.  
* Update demo app to demo the `horizontalPageMargin` setting behavior. The scroll view must have `clipsToBounds` disabled and its width smaller than its superview for the margin behavior to show best how it works.
